### PR TITLE
Use out instead of fmt for printing

### DIFF
--- a/csv-to-json.go
+++ b/csv-to-json.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/csv"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -55,5 +54,5 @@ func main() {
 		out.Write(jsonStr)
 
 	}
-	fmt.Print("]")
+	out.WriteString("]")
 }


### PR DESCRIPTION
csv-to-json tool is not printing "]" in the end of the output json, and the outcome is incorrect json format